### PR TITLE
update styles, home and footer

### DIFF
--- a/graphery/src/components/framework/Footer.vue
+++ b/graphery/src/components/framework/Footer.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="footer-wrapper q-pa-md">
+  <div class="footer-wrapper">
     <div class="justify-between footer-container">
-      <div class="left-section row">
+      <div class="left-section">
         <div class="logo flex no-wrap justify-start">
           <div
             class="logo-text"
@@ -109,10 +109,19 @@
     color: grey
     max-width: $material-page-max-width
     margin: -70px auto 48px
+    padding: 0 32px
 
     .footer-container
+      display: flex
+      flex-direction: row
+      @media (max-width: $breakpoint-sm-max)
+        flex-direction: column
       .left-section
-        @media (max-width: $breakpoint-md-max)
+        display: flex
+        flex-direction: row
+        @media (max-width: $breakpoint-sm-max)
+          margin-bottom: 10px
+          flex-direction: column
           justify-content: center
           align-items: center
           text-align: center
@@ -130,7 +139,7 @@
         .icon-row
           margin-left: 30px
           margin-top: 3px
-          @media (max-width: $breakpoint-md-max)
+          @media (max-width: $breakpoint-sm-max)
             margin-left: 0
             margin-top: -6px
           // adjust the line height
@@ -142,7 +151,7 @@
 
       .right-section
         text-align: right
-        @media (max-width: $breakpoint-md-max)
+        @media (max-width: $breakpoint-sm-max)
           text-align: center
         & i
           margin-right: 1px

--- a/graphery/src/components/framework/MaterialCover.vue
+++ b/graphery/src/components/framework/MaterialCover.vue
@@ -26,16 +26,17 @@
   .cover-wrapper
     background-color: #A70E16
     height: 180px
+    $general-opacity: .15
     .cover-text
       margin-left: 2rem
       margin-top: -2rem
-      opacity: .1
+      opacity: $general-opacity
       color: #fff
       font-size: 9rem
 
     .logo
       width: 300px
       height: 300px
-      opacity: .1
+      opacity: $general-opacity
       margin-right: 2rem
 </style>

--- a/graphery/src/styles/home.sass
+++ b/graphery/src/styles/home.sass
@@ -8,7 +8,7 @@
     font-weight: bold
 .welcome-box
   //display: flex
-  margin: 1.5rem 0
+  margin: 1rem 0
   align-items: center
   flex-direction: row
   //justify-content: space-between
@@ -18,21 +18,34 @@
   .logo
     height: 250px
     width: 250px
+    @media (max-width: $breakpoint-sm-max)
+      height: 150px
+      width: 150px
   .graphery-text
     text-align: center
     padding: 0 30px
     .welcome-title
       font-family: Georgia, serif
       margin: 20px auto
+      @media (min-width: $breakpoint-sm-max)
+        margin-left: -50px
+      @media (max-width: $breakpoint-sm-max)
+        font-size: 40px
       .logo-text
         font-family: "Amiri", serif
         color: $primary
-        margin-left: 50px
+        margin-left: 100px
         @media (max-width: $breakpoint-sm-max)
-          margin-left: 15px
+          margin-left: 1px
     .home-intro-text
+      text-align: left
       font-size: 18px
       line-height: 20px
+      @media (max-width: $breakpoint-sm-max)
+        font-size: 14px
+        line-height: 18px
+        margin: auto -10px
+
       p
         margin-bottom: 7px
 .quick-facts
@@ -53,9 +66,16 @@
     .icon
       font-size: 100px
       color: $primary
-    .title
-      font-size: x-large
-    .description
-      p
-        font-size: 18px
+    .text-wrapper
+      display: flex
+      flex-direction: column
+      align-items: center
+      .title
+        font-size: 25px
+        font-family: "Amiri", serif
+        //font-weight: bold
+        margin-bottom: 10px
+      .description
+        p
+          font-size: 16px
 

--- a/graphery/src/views/About.vue
+++ b/graphery/src/views/About.vue
@@ -84,8 +84,7 @@
             This project is supported by an NSF CAREER Award (<a
               href="https://nsf.gov/awardsearch/showAward?AWD_ID=1750981"
               target="_blank"
-            >
-              DBI-1750981</a
+              >DBI-1750981</a
             >) to Anna Ritz.
           </p>
         </section>

--- a/graphery/src/views/Home.vue
+++ b/graphery/src/views/Home.vue
@@ -9,7 +9,7 @@
         >
           <!-- FIXME: mobile breakpoint (responsive adaption)-->
           <!-- FIXME: beautify the logo -->
-          <div :class="[mdColControl]" class="justify-center">
+          <div :class="[mdColControl]" class="flex justify-center">
             <img :src="logoSrc" class="logo" alt="site logo" />
           </div>
           <div :class="[mdColControl]" class="graphery-text justify-center">
@@ -45,11 +45,13 @@
               <div class="icon">
                 <q-icon :name="item.icon"></q-icon>
               </div>
-              <div :class="['title', mdColControl]">{{ item.title }}</div>
-              <div :class="['description', mdColControl]">
-                <p>
-                  {{ item.description }}
-                </p>
+              <div class="text-wrapper">
+                <div :class="['title', mdColControl]">{{ item.title }}</div>
+                <div :class="['description', mdColControl]">
+                  <p>
+                    {{ item.description }}
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -80,7 +82,7 @@
             icon: 'mdi-script-text-outline',
           },
           {
-            title: 'Interactive Graphs and Customizable Code',
+            title: 'Interactive',
             description:
               'Provide interactive graphs and allow users to write their own code to interact with existing graphs',
             icon: 'mdi-cursor-default-click-outline',


### PR DESCRIPTION
The home and footer are updated. The footer now is more explicit on mobile devices.

I've changed the title of the second feature, the previous one is too long. (but consider the other two titles are nouns?)

![image](https://user-images.githubusercontent.com/15688641/105612056-3951d600-5df4-11eb-8d27-15364b433126.png)

Here's the mobile version

<img src="https://user-images.githubusercontent.com/15688641/105612075-630afd00-5df4-11eb-8ed3-e0ed929533d1.png" width="45%">


## TBD
- The intro text of home page should be centered on mobile devices(responsive)

## Known issue
The breakpoint is not precise, some issues occurred on the iPad and iPad Pro.