### PR TITLE
Update TOS and FAQ

### DIFF
--- a/graphery/src/components/framework/TOSPopup.vue
+++ b/graphery/src/components/framework/TOSPopup.vue
@@ -12,21 +12,21 @@
       showTOSTerms() {
         if (!this.$store.state.settings.tosAgreeAndDoNotShowAgain) {
           Notify.create({
-            type: 'warning',
-            caption: 'Agreement',
-            message:
-              'By proceeding you agree to the terms of service and privacy notice',
+            type: 'gdpr',
+            caption:
+              'By continuing to access Graphery, you agree to the terms of service and privacy notice',
+            message: 'Cookies helps us improve your experience',
             group: false,
             timeout: 0,
             multiLine: true,
             actions: [
               {
-                label: 'Read the terms of service and privacy notices',
-                color: 'primary',
+                label: 'Learn more',
+                color: 'warning',
                 handler: this.jumpToTOS,
               },
               {
-                label: 'Agree and never show again',
+                label: 'Close',
                 color: 'white',
                 handler: this.agreeTos,
               },
@@ -34,6 +34,15 @@
           });
         }
       },
+    },
+    created() {
+      this.$q.notify.registerType('gdpr', {
+        icon: 'privacy_tip',
+        // color: 'grey',
+        textColor: 'white',
+        position: 'bottom-right',
+        classes: 'gdpr',
+      });
     },
   };
 </script>

--- a/graphery/src/components/static/faq_en_us.md
+++ b/graphery/src/components/static/faq_en_us.md
@@ -1,0 +1,9 @@
+### What is Graphery?
+
+### How do I use it?
+
+### How to run my own code on Graphery?
+
+### I found a bug, how to report it?
+
+### Can I make contributions to Graphery?

--- a/graphery/src/components/static/tos_en_us.md
+++ b/graphery/src/components/static/tos_en_us.md
@@ -1,3 +1,10 @@
-Privacy Policy: By using [Graphery](https://graphery.reedcompbio.org), your visualized code, options, user interactions, and IP address are logged on our server and your activities (viewed pages, viewport movements, and click events) by Google Analytics. Nearly all web services collect this basic information from users in their server logs. However, Graphery does not collect any personally identifiable information from its users. 
+The Graphery service is provided for free on an as-is basis. Use this service at your own risk. Do not use it to share confidential information. The developers of Graphery are not responsible for the actions of any of the users on this website. We are also not responsible for any damages caused by using this website. Finally, it is your responsibility to follow appropriate academic integrity standards. All articles(tutorials, graphs, etc.) without special specification are licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+<img
+alt="Creative Commons License"
+style="border-width:0"
+src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"
+/>
 
-Terms of Service: The Graphery service is provided for free on an as-is basis. Use this service at your own risk. Do not use it to share confidential information. The developers of Graphery are not responsible for the actions of any of the users on this website. We are also not responsible for any damages caused by using this website. Finally, it is your responsibility to follow appropriate academic integrity standards.
+### Privacy Policy
+
+By using [Graphery](https://graphery.reedcompbio.org), your visualized code, options, user interactions, and IP address are logged on our server and your activities (viewed pages, viewport movements, and click events) by Google Analytics. Nearly all web services collect this basic information from users in their server logs. However, Graphery does not collect any personally identifiable information from its users.

--- a/graphery/src/locales/en-us.json
+++ b/graphery/src/locales/en-us.json
@@ -33,7 +33,7 @@
     "EmailUs": "Email Us",
     "GithubRepo": "Github Repo",
     "tos": "Terms of Services",
-    "faq": "FAQ"
+    "faq": "Frequently Asked Questions"
   },
   "tos": {},
   "faq": {},

--- a/graphery/src/styles/global.sass
+++ b/graphery/src/styles/global.sass
@@ -15,3 +15,7 @@ $splitter-line-width: 10px
 
 .material-page-shorter-h3
   margin-bottom: 20px
+
+.gdpr
+  max-width: 350px !important
+

--- a/graphery/src/views/About.vue
+++ b/graphery/src/views/About.vue
@@ -35,12 +35,24 @@
             biological applications such as animal social networks, ecology food
             webs, molecular interaction networks, and phylogenetic trees.
           </p>
+          <p>
+            We collect By accessing Graphery, you agree to the terms of service
+            and privacy notice,
+            <router-link :to="{ name: 'TOS' }">learn more</router-link>.
+          </p>
         </section>
         <section>
           <h4 id="feedback">
             Feedback
           </h4>
           <div>
+            <p>
+              Check
+              <router-link :to="{ name: 'FAQ' }"
+                >Frequently Asked Questions (FAQ)
+              </router-link>
+              first, or
+            </p>
             <FeedbackDropdown />
           </div>
         </section>

--- a/graphery/src/views/FAQ.vue
+++ b/graphery/src/views/FAQ.vue
@@ -8,13 +8,11 @@
         </h3>
         <q-separator />
       </header>
-      <body>
-        <!-- example questions -->
-        <p v-for="(item, index) in examples" :key="index">
-          {{ index + 1 }}.
-          {{ item }}
-        </p>
-      </body>
+      <section>
+        <div class="q-my-lg q-pa-sm">
+          <MarkdownSection :markdown-raw="faq" />
+        </div>
+      </section>
     </MaterialPage>
   </div>
 </template>
@@ -22,11 +20,22 @@
 <script>
   import MaterialCover from '@/components/framework/MaterialCover';
   import MaterialPage from '@/components/framework/MaterialPage';
+  import MarkdownSection from '@/components/framework/md/MarkdownSection';
   export default {
     name: 'FAQ',
-    components: { MaterialPage, MaterialCover },
+    components: { MarkdownSection, MaterialPage, MaterialCover },
     data() {
       return {
+        faq_: `### What is Graphery?
+
+### How do I use it?
+
+### How to run my own code on Graphery?
+
+### I found a bug, how to report it?
+
+### Can I make contributions to Graphery?
+`,
         examples: [
           'What is Graphery?',
           'How do I use it?',
@@ -36,7 +45,12 @@
         ],
       };
     },
+    computed: {
+      faq() {
+        return this.faq_;
+      },
+    },
   };
 </script>
 
-<style scoped></style>
+<style lang="sass" scoped></style>

--- a/graphery/src/views/FAQ.vue
+++ b/graphery/src/views/FAQ.vue
@@ -3,9 +3,7 @@
     <MaterialCover :cover-title="$t('nav.faq')" />
     <MaterialPage>
       <header>
-        <h3 class="material-page-shorter-h3">
-          {{ $t('nav.faq') }}
-        </h3>
+        <h3 class="material-page-shorter-h3">{{ $t('nav.faq') }} (FAQ)</h3>
         <q-separator />
       </header>
       <section>

--- a/graphery/src/views/TOS.vue
+++ b/graphery/src/views/TOS.vue
@@ -24,9 +24,18 @@
     components: { MarkdownSection, MaterialPage, MaterialCover },
     data() {
       return {
-        tosContent_: `Privacy Policy: By using [Graphery](https://graphery.reedcompbio.org), your visualized code, options, user interactions, and IP address are logged on our server and your activities (viewed pages, viewport movements, and click events) by Google Analytics. Nearly all web services collect this basic information from users in their server logs. However, Graphery does not collect any personally identifiable information from its users.
+        tosContent_: `The Graphery service is provided for free on an as-is basis. Use this service at your own risk. Do not use it to share confidential information. The developers of Graphery are not responsible for the actions of any of the users on this website. We are also not responsible for any damages caused by using this website. Finally, it is your responsibility to follow appropriate academic integrity standards. All articles(tutorials, graphs, etc.) without special specification are licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/)
+<img
+alt="Creative Commons License"
+style="border-width:0"
+src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"
+/>
 
-Terms of Service: The Graphery service is provided for free on an as-is basis. Use this service at your own risk. Do not use it to share confidential information. The developers of Graphery are not responsible for the actions of any of the users on this website. We are also not responsible for any damages caused by using this website. Finally, it is your responsibility to follow appropriate academic integrity standards.`,
+
+### Privacy Policy
+
+By using [Graphery](https://graphery.reedcompbio.org), your visualized code, options, user interactions, and IP address are logged on our server and your activities (viewed pages, viewport movements, and click events) by Google Analytics. Nearly all web services collect this basic information from users in their server logs. However, Graphery does not collect any personally identifiable information from its users.
+`,
       };
     },
     computed: {

--- a/graphery/src/views/TOS.vue
+++ b/graphery/src/views/TOS.vue
@@ -7,7 +7,7 @@
         <q-separator />
       </header>
       <section>
-        <div class="q-my-lg q-pa-sm q-px-md">
+        <div class="q-my-lg q-pa-sm ">
           <MarkdownSection :markdown-raw="tosContent" />
         </div>
       </section>


### PR DESCRIPTION
## What's new
- TOS page and TOS(GDPR) popup are updated
- Link FAQ and TOS on the About page #151

## Known issues
- the cookies(and other definitions) are not included on the TOS page
- FAQ - Answers to questions #151 
- The top-bottom margin on the About page is too large 

## TBD
- [ ] The privacy notice should be expanded in every detail, definition, refer to [this website](https://www.arweave.org/cookies-policy)
- [ ] Enrich the content of FAQ #151, add more user-friendly context on that page(like welcoming, and navigations)
- [ ] modify the styles on the About page

## Proposals
- We may replace Privacy Notice with Privacy Policy since we gonna expand every detail of it
- How about getting directly the content of .md file directly to the vue page, in this case we can make changes quickly without a second copy-paste to data property @FlickerSoul 

## Assets
### Pop-up
![popup](https://user-images.githubusercontent.com/15688641/107845239-0b6d1980-6e15-11eb-882f-1921b975d48e.png)

### TOS page
![tos](https://user-images.githubusercontent.com/15688641/107845389-fd6bc880-6e15-11eb-87a8-2db355e90d1c.png)

### FAQ page
![faq](https://user-images.githubusercontent.com/15688641/107845383-f1800680-6e15-11eb-8ef3-6739cab10da7.png)

### About page
![about](https://user-images.githubusercontent.com/15688641/107845401-08bef400-6e16-11eb-9b98-ce327628d10c.png)
